### PR TITLE
Update configjoin.js

### DIFF
--- a/commands/config/configjoin.js
+++ b/commands/config/configjoin.js
@@ -27,7 +27,7 @@ module.exports = class extends Command {
         let collected = await message.channel.awaitMessages(filter, opt).catch(() => {});
         if (!collected || !collected.first()) return msg.error("common:CANCELLED", null, true);
         const confMessage = collected.first().content;
-        if (confMessage.length > 1000) return msg.edit(message.language.configjoin.longmessage());
+        if (confMessage.length > 1000) return msg.edit("TheMessage :D");
         if (confMessage === "cancel") return msg.error("common:CANCELLED", null, true);
         if (confMessage === data.guild.prefix+"setjoin") return;
         collected.first().delete();

--- a/commands/config/configjoin.js
+++ b/commands/config/configjoin.js
@@ -27,6 +27,7 @@ module.exports = class extends Command {
         let collected = await message.channel.awaitMessages(filter, opt).catch(() => {});
         if (!collected || !collected.first()) return msg.error("common:CANCELLED", null, true);
         const confMessage = collected.first().content;
+        if (confMessage.length > 1000) return msg.edit(message.language.configjoin.longmessage());
         if (confMessage === "cancel") return msg.error("common:CANCELLED", null, true);
         if (confMessage === data.guild.prefix+"setjoin") return;
         collected.first().delete();


### PR DESCRIPTION
Limite the join message because if you set a very long message like 2000 caractères Manage Invite cannot send the message